### PR TITLE
Sample security improvement with getpass

### DIFF
--- a/sample/getallvms.py
+++ b/sample/getallvms.py
@@ -25,6 +25,7 @@ from pyVmomi import vmodl
 import argparse
 import atexit
 import sys
+import getpass
 
 
 def GetArgs():
@@ -35,7 +36,6 @@ def GetArgs():
    parser.add_argument('-s', '--host', required=True, action='store', help='Remote host to connect to')
    parser.add_argument('-o', '--port', type=int, default=443,   action='store', help='Port to connect on')
    parser.add_argument('-u', '--user', required=True, action='store', help='User name to use when connecting to host')
-   parser.add_argument('-p', '--password', required=True, action='store', help='Password to use when connecting to host')
    args = parser.parse_args()
    return args
 
@@ -77,12 +77,14 @@ def main():
    """
 
    args = GetArgs()
+   password = getpass.getpass(prompt='Enter password for host %s and user %s: ' % (args.host,args.user))
+
    try:
       si = None
       try:
          si = SmartConnect(host=args.host,
                 user=args.user,
-                pwd=args.password,
+                pwd=password,
                 port=int(args.port))
       except IOError, e:
         pass

--- a/sample/poweronvm.py
+++ b/sample/poweronvm.py
@@ -25,6 +25,7 @@ from pyVmomi import vim, vmodl
 import argparse
 import atexit
 import sys
+import getpass
 
 def GetArgs():
    """
@@ -35,7 +36,6 @@ def GetArgs():
    parser.add_argument('-s', '--host', required=True, action='store', help='Remote host to connect to')
    parser.add_argument('-o', '--port', type=int, default=443, action='store', help='Port to connect on')
    parser.add_argument('-u', '--user', required=True, action='store', help='User name to use when connecting to host')
-   parser.add_argument('-p', '--password', required=True, action='store', help='Password to use when connecting to host')
    parser.add_argument('-v', '--vmname', required=True, action='append', help='Names of the Virtual Machines to power on')
    args = parser.parse_args()
    return args
@@ -98,6 +98,8 @@ def main():
    """
 
    args = GetArgs()
+   password = getpass.getpass(prompt='Enter password for host %s and user %s: ' % (args.host,args.user))
+
    try:
       vmnames = args.vmname
       if not len(vmnames):
@@ -108,7 +110,7 @@ def main():
       try:
          si = SmartConnect(host=args.host,
                            user=args.user,
-                           pwd=args.password,
+                           pwd=password,
                            port=int(args.port))
       except IOError, e:
          pass


### PR DESCRIPTION
Using getpass to get the connection password in a save way, this way,
the password is not visible on the command line and the shell's history
