### PR TITLE
Giving users the option to not use the password on the command line

### DIFF
--- a/sample/getallvms.py
+++ b/sample/getallvms.py
@@ -24,8 +24,8 @@ from pyVmomi import vmodl
 
 import argparse
 import atexit
-import sys
 import getpass
+import sys
 
 
 def GetArgs():

--- a/sample/poweronvm.py
+++ b/sample/poweronvm.py
@@ -24,8 +24,8 @@ from pyVmomi import vim, vmodl
 
 import argparse
 import atexit
-import sys
 import getpass
+import sys
 
 def GetArgs():
    """


### PR DESCRIPTION
This will improve security as the password is not visible on the command line or in the shell's command history.

The option to still use a command line password is still there, in case somebody wants to use it in another script, in which case a prompt is not an option.
