### PR TITLE
Fix SSL error when connecting from behind a proxy

### DIFF
--- a/pyVim/connect.py
+++ b/pyVim/connect.py
@@ -427,8 +427,6 @@ def __GetServiceVersionDescription(protocol, server, port, path):
 
    tree = ElementTree()
 
-   import urllib2
-
    url = "%s://%s:%s/%s/vimServiceVersions.xml" % (protocol, server, port, path)
    try:
       with closing(urllib2.urlopen(url)) as sock:


### PR DESCRIPTION
In certain versions of python, urllib fails when making https requests from behind a proxy. See http://bugs.python.org/issue1424152 for details.

This patch fixes an issue with pyVim by using urllib2 instead of urllib, a change similar to existing code (see `OpenUrlWithBasicAuth()` and `OpenPathWithStub()`).
### Steps to Reproduce

**test.py** example script

``` python
# assume imports and server hostname, user, etc are defined here
...
def main():
    try:
        si = None
        try:
            #pdb.set_trace()
            si = SmartConnect(host=HOSTNAME, user=USERNAME, pwd=PASSWORD, port=443)
        except IOError, e:
            pp.pprint(e)
            pass
        if not si:
            print "Could not connect to host: " + HOSTNAME
            return -1

        atexit.register(Disconnect, si)
        content = si.RetrieveContent()
        sm = content.sessionManager
        try:
            sessions = sm.sessionList
            pp.pprint(sessions)
        except IndexError:
            print "No sessions found"
            return -1

    except vmodl.MethodFault, e:
        print "Caught vmodl fault: " + e.msg
        return -1
    except Exception, e:
        print "Caught exception: " + str(e)
        return -1
    return 0

if __name__ == "__main__":
    main()
```

`somehost` is behind a Squid proxy.

```
(pytest)[user@somehost vmware-pyscripts]$ python test.py
IOError('socket error', SSLError(1, '_ssl.c:492: error:140770FC:SSL routines:SSL23_GET_SERVER_HELLO:unknown protocol'))
Could not connect to host: vcenter-dev.somewhere.oregonstate.edu
(pytest)[user@somehost vmware-pyscripts]$ pip freeze
pyvmomi==5.5.0
(pytest)[user@somehost vmware-pyscripts]$ python --version
Python 2.6.6
```
