### PR TITLE
Change urllib to urllib2

### DIFF
--- a/pyVim/connect.py
+++ b/pyVim/connect.py
@@ -41,7 +41,7 @@ try:
 except ImportError:
    from elementtree.ElementTree import ElementTree
 from xml.parsers.expat import ExpatError
-import urllib
+import urllib2
 
 
 """
@@ -429,7 +429,7 @@ def __GetServiceVersionDescription(protocol, server, port, path):
 
    url = "%s://%s:%s/%s/vimServiceVersions.xml" % (protocol, server, port, path)
    try:
-      with closing(urllib.urlopen(url)) as sock:
+      with closing(urllib2.urlopen(url)) as sock:
          if sock.getcode() == 200:
             tree.parse(sock)
             return tree
@@ -438,7 +438,7 @@ def __GetServiceVersionDescription(protocol, server, port, path):
 
    url = "%s://%s:%s/%s/vimService.wsdl" % (protocol, server, port, path)
    try:
-      with closing(urllib.urlopen(url)) as sock:
+      with closing(urllib2.urlopen(url)) as sock:
          if sock.getcode() == 200:
             tree.parse(sock)
             return tree


### PR DESCRIPTION
Change urllib to urllib2 to void blocking with Keep-Alive connections.

Only in those two places urllib issued. Other places in the same file, urllib2 is used. Hence changed the urllib to urllib2.

https://github.com/vmware/pyvmomi/issues/17
