### PR TITLE
added travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: python
+python:
+    - "2.6"
+    - "2.7"
+    - "pypy"
+
+before_install:
+    - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
+
+install:
+    - python setup.py bdist_egg
+    - pip install -e file://$TRAVIS_BUILD_DIR
+
+script:
+    nosetests


### PR DESCRIPTION
Adding a travis-ci file. I have a branch where I am using travis-ci to preform unit tests.

I did not include python 3 in this file because this project does not seem to support it.

https://travis-ci.org/michaelrice/pyvmomi/jobs/27107737
https://travis-ci.org/michaelrice/pyvmomi/jobs/27107738
Also seen here: 
https://jenkins.toastcoders.com/view/pyvmomi/job/python-pyvmomi-mine-tests-3.1.5/1/console

EDIT:
I think this also starts to add support to address issue #42 
