### PR TITLE
Malformed Faults fail in non-informative ways

### DIFF
--- a/pyVmomi/SoapAdapter.py
+++ b/pyVmomi/SoapAdapter.py
@@ -566,7 +566,15 @@ class SoapDeserializer(ExpatDeserializerNSHandlers):
       if not self.stack:
          if self.isFault:
             ns, name = self.SplitTag(tag)
-            objType = self.LookupWsdlType(ns, name[:-5])
+            try:
+                objType = self.LookupWsdlType(ns, name[:-5])
+            except:
+                fault_name = name[:-5]
+                vmodl_name = "vmodl.fault." + fault_name
+                CreateDataType(str(vmodl_name), str(fault_name),
+                               "vmodl.RuntimeFault", "vmodl.version.version0",
+                               None)
+                objType = self.LookupWsdlType(ns, fault_name)
             # Only top level soap fault should be deserialized as method fault
             deserializeAsLocalizedMethodFault = False
          else:


### PR DESCRIPTION
example: LicenseUsageFault

```
  <soapenv:Body>
    <soapenv:Fault>
      <faultcode>ServerFaultCode</faultcode>
      <faultstring/>
      <detail>
        <LicenseUsageFaultFault xsi:type="LicenseUsageFault">
           <reason>dataTampered</reason></LicenseUsageFaultFault>
      </detail>
    </soapenv:Fault>
```

The detail tag's first child represents the data type to unmarshal the Fault message envelope's contents into. If that child tag does not have a matching WSDL definition pyVmomi fails to raise the fault. The exception raised is KeyError and contains no details about the fault. Instead, an end user should see additional information so they can report the bug accurately.

This change lets the library dynamically create the new fault data type at runtime.

closes https://github.com/vmware/pyvmomi/issues/72
