### PR TITLE
Remove calls to atexit in tests

### DIFF
--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -68,5 +68,8 @@ class ConnectionTests(unittest.TestCase):
         self.assertTrue(session_id is not None)
         self.assertEqual('52773cd3-35c6-b40a-17f1-fe664a9f08f3', session_id)
 
+    def test_disconnect_on_no_connection(self):
+        connect.Disconnect(None)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_container_view.py
+++ b/tests/test_container_view.py
@@ -12,10 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import atexit
 from tests import fixtures_path
 import logging
-from pprint import pprint
 import unittest
 import vcr
 
@@ -37,7 +35,6 @@ class ContainerViewTests(unittest.TestCase):
         si = connect.SmartConnect(host='vcsa',
                                   user='my_user',
                                   pwd='my_password')
-        atexit.register(connect.Disconnect, si)
 
         content = si.RetrieveContent()
 

--- a/tests/test_iso8601.py
+++ b/tests/test_iso8601.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import atexit
 from datetime import datetime
 from datetime import timedelta
 
@@ -32,7 +31,6 @@ class Iso8601Tests(unittest.TestCase):
         si = connect.SmartConnect(host='vcsa',
                                   user='my_user',
                                   pwd='my_password')
-        atexit.register(connect.Disconnect, si)
 
         search_index = si.content.searchIndex
         uuid = "5001ad1b-c78d-179e-ecd7-1cc0e1cf1b96"
@@ -92,7 +90,6 @@ class Iso8601Tests(unittest.TestCase):
             si = connect.SmartConnect(host='vcsa',
                                       user='my_user',
                                       pwd='my_password')
-            atexit.register(connect.Disconnect, si)
 
             search_index = si.content.searchIndex
             uuid = "4c4c4544-0043-4d10-8056-b1c04f4c5331"


### PR DESCRIPTION
When using `atexit.register(connect.Disconnect, si)` in a test
the test framework process will create extra trace when it exits.
To avoid producing this trace, remove all calls to atexit in tests.

fixes: https://github.com/vmware/pyvmomi/issues/131
