### PR TITLE
respect venv

### DIFF
--- a/sample/getallvms.py
+++ b/sample/getallvms.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # VMware vSphere Python SDK
 # Copyright (c) 2008-2013 VMware, Inc. All Rights Reserved.
 #

--- a/sample/poweronvm.py
+++ b/sample/poweronvm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # VMware vSphere Python SDK
 # Copyright (c) 2008-2014 VMware, Inc. All Rights Reserved.


### PR DESCRIPTION
Change shebang to use env to ask for the python interpreter,
this allows the scripts to run while respecting a virtual
environment.

Closes: https://github.com/vmware/pyvmomi/issues/151
