### PR TITLE
Adds a sensible workaround to connect.py for ipv6

### DIFF
--- a/pyVim/connect.py
+++ b/pyVim/connect.py
@@ -23,6 +23,8 @@ Connect to a VMOMI ServiceInstance.
 
 Detailed description (for [e]pydoc goes here).
 """
+import socket
+
 from six import reraise
 import sys
 import re
@@ -429,8 +431,11 @@ def __GetServiceVersionDescription(protocol, server, port, path):
    @param path: Path
    @type  path: string
    """
-
-   url = "%s://%s:%s/%s/vimServiceVersions.xml" % (protocol, server, port, path)
+   try:
+      socket.inet_pton(socket.AF_INET6, server)
+      url = "%s://[%s]:%s/%s/vimServiceVersions.xml" % (protocol, server, port, path)
+   except:
+      url = "%s://%s:%s/%s/vimServiceVersions.xml" % (protocol, server, port, path)
    try:
       sock = requests.get(url, verify=False)
       if sock.status_code == 200:


### PR DESCRIPTION
Issue raised stating ipv6 connectivity was failing
due to missing "[]" around the address. This patch
includes the socket module and attempts to validate
an address to be ipv6. If successful it will add the
needed "[]" around the address. If an exception is
raised then that means the address is not a valid
ipv6 so we assume it is a hostname or ipv4 and treat
it normally.

Fixes #244