### PR TITLE
XML serialization for certain types is broken on Python 3

### DIFF
--- a/pyVmomi/SoapAdapter.py
+++ b/pyVmomi/SoapAdapter.py
@@ -392,16 +392,21 @@ class SoapSerializer:
             else:
                nsattr, qName = self._QName(Type(val), currDefNS)
                attr += '{0} {1}type="{2}"'.format(nsattr, self.xsiPrefix, qName)
-         if not isinstance(val, text_type):
-            # Use UTF-8 rather than self.encoding.  self.encoding is for
-            # output of serializer, while 'val' is our input.  And regardless
-            # of what our output is, our input should be always UTF-8.  Yes,
-            # it means that if you emit output in other encoding than UTF-8,
-            # you cannot serialize it again once more.  That's feature, not
-            # a bug.
-            val = str(val)
-            if PY2:
-               val = val.decode('UTF-8')
+
+         # For some pyVmomi objects, isinstance(val, text_type) is True, but
+         # that object overrides certain string methods that are needed later.
+         # Convert val to a real string, regardless of its type.
+         val = str(val)
+
+         # Use UTF-8 rather than self.encoding.  self.encoding is for
+         # output of serializer, while 'val' is our input.  And regardless
+         # of what our output is, our input should be always UTF-8.  Yes,
+         # it means that if you emit output in other encoding than UTF-8,
+         # you cannot serialize it again once more.  That's feature, not
+         # a bug.
+         if PY2:
+            val = val.decode('UTF-8')
+
          result = XmlEscape(val)
          self.writer.write('<{0}{1}>{2}</{0}>'.format(info.name, attr,
                                                       encode(result,

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -16,6 +16,7 @@ import tests
 import vcr
 
 
+from pyVmomi import SoapAdapter
 from pyVmomi import SoapStubAdapter
 from pyVmomi import vim
 
@@ -52,3 +53,8 @@ class SerializerTests(tests.VCRTestBase):
             self.assertTrue(
                 '<_this type="ServiceInstance">ServiceInstance</_this>'
                 in cass.requests[0].body.decode("utf-8"))
+
+    def test_serialize_object(self):
+        val = vim.vm.device.VirtualDeviceSpec.FileOperation()
+        # This line should not raise an exception, especially on Python 3.
+        SoapAdapter.Serialize(val)


### PR DESCRIPTION
XML serialization does not work for certain types on Python 3. This is best illustrated by example:

On Python 2.7:

    >>> val = pyVmomi.vim.vm.device.VirtualDeviceSpec.FileOperation()
    >>> pyVmomi.SoapAdapter.Serialize(val)
    '<object xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="urn:vim25" xsi:type="VirtualDeviceConfigSpecFileOperation"></object>'
    >>> from six import text_type
    >>> isinstance(val, text_type)
    False
    >>> val.replace
    'replace'


On Python 3.4:

    >>> val = pyVmomi.vim.vm.device.VirtualDeviceSpec.FileOperation()
    >>> pyVmomi.SoapAdapter.Serialize(val)
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/home/mstunes/projects/uwsimscripts2/lib/python3.4/site-packages/pyVmomi/SoapAdapter.py", line 154, in Serialize
        SoapSerializer(writer, version, nsMap, encoding).Serialize(val, info)
      File "/home/mstunes/projects/uwsimscripts2/lib/python3.4/site-packages/pyVmomi/SoapAdapter.py", line 227, in Serialize
        self._Serialize(val, info, self.defaultNS)
      File "/home/mstunes/projects/uwsimscripts2/lib/python3.4/site-packages/pyVmomi/SoapAdapter.py", line 405, in _Serialize
        result = XmlEscape(val)
      File "/home/mstunes/projects/uwsimscripts2/lib/python3.4/site-packages/pyVmomi/SoapAdapter.py", line 109, in XmlEscape
        escaped = xmlStr.replace("&", "&amp;").replace(">", "&gt;").replace("<", "&lt;")
    TypeError: 'vim.vm.device.VirtualDeviceSpec.FileOperation' object is not callable
    >>> 
    >>> from six import text_type
    >>> isinstance(val, text_type)
    True
    >>> val.replace
    'replace'

At SoapAdapter.py:395 (in SoapSerializer._Serialize), the object is checked for isinstance(val, text_type). The result of that comparison is different across versions: on Python 2.7, text_type is 'unicode'; on Python 3.4, text_type is 'str'. As a result, on Python 2.7, val is explicitly converted to a str, whereas no such conversion happens in 3.4. Also, this object has a 'replace' attribute, which is a real function on str objects, but on a FileOperation object, the 'replace' attribute is not a function. Thus, _Serialize fails at runtime when calling replace() on Python 3.4.