### PR TITLE
fix issue #293

### DIFF
--- a/pyVmomi/SoapAdapter.py
+++ b/pyVmomi/SoapAdapter.py
@@ -1569,6 +1569,8 @@ class SessionOrientedStub(StubAdapterBase):
             if isinstance(e, self.SESSION_EXCEPTIONS):
                # Our session might've timed out, change our state and retry.
                self._SetStateUnauthenticated()
+               retriesLeft -= 1
+               continue
             else:
                raise e
          return obj

--- a/tests/test_vim_session_oriented_stub.py
+++ b/tests/test_vim_session_oriented_stub.py
@@ -1,0 +1,17 @@
+import tests
+import unittest
+
+from pyVim import connect
+from pyVmomi import SoapAdapter
+
+
+class SoapAdapterTests(tests.VCRTestBase):
+
+  def test_invoke_method_login_session_exception(self):
+
+    def login_fail(*args, **kwargs):
+      raise vim_session.SESSION_EXCEPTIONS[0]()
+
+    stub = connect.SoapStubAdapter()
+    vim_session = connect.VimSessionOrientedStub(stub, login_fail)
+    self.assertRaises(SystemError, vim_session.InvokeAccessor, "mo", "info")


### PR DESCRIPTION
UnboundLocalError: local variable 'obj' referenced before assignment
in SoapAdapter.py when using VimSessionOrientedStub #239

unittest before change
UnboundLocalError: local variable 'obj' referenced before assignment

After change SystemError exception is raised

Note: This issue #393 prevents InvokeAccessor from attempting to
re-login.