### PR TITLE
Allow cacertsfile to be specified when connecting. Addresses issues 235, 212

### DIFF
--- a/pyVim/connect.py
+++ b/pyVim/connect.py
@@ -179,7 +179,7 @@ class VimSessionOrientedStub(SessionOrientedStub):
 
 def Connect(host='localhost', port=443, user='root', pwd='',
             service="hostd", adapter="SOAP", namespace=None, path="/sdk",
-            version=None, keyFile=None, certFile=None):
+            version=None, keyFile=None, certFile=None, cacertsFile=None):
    """
    Connect to the specified server, login and return the service
    instance object.
@@ -213,6 +213,8 @@ def Connect(host='localhost', port=443, user='root', pwd='',
    @type  keyFile: string
    @param certFile: ssl cert file path
    @type  certFile: string
+   @param cacertsFile CA certificates file in PEM format
+   @type  cacertsFile: string
    """
    try:
       info = re.match(_rx, host)
@@ -231,7 +233,7 @@ def Connect(host='localhost', port=443, user='root', pwd='',
    elif not version:
       version="vim.version.version6"
    si, stub = __Login(host, port, user, pwd, service, adapter, version, path,
-                      keyFile, certFile)
+                      keyFile, certFile, cacertsFile)
    SetSi(si)
 
    return si
@@ -266,7 +268,7 @@ def GetLocalTicket(si, user):
 ## connected service instance object.
 
 def __Login(host, port, user, pwd, service, adapter, version, path,
-            keyFile, certFile):
+            keyFile, certFile, cacertsFile):
    """
    Private method that performs the actual Connect and returns a
    connected service instance object.
@@ -291,6 +293,8 @@ def __Login(host, port, user, pwd, service, adapter, version, path,
    @type  keyFile: string
    @param certFile: ssl cert file path
    @type  certFile: string
+   @param cacertsFile CA certificates file in PEM format
+   @type  cacertsFile: string
    """
 
    # XXX remove the adapter and service arguments once dependent code is fixed
@@ -299,7 +303,8 @@ def __Login(host, port, user, pwd, service, adapter, version, path,
 
    # Create the SOAP stub adapter
    stub = SoapStubAdapter(host, port, version=version, path=path,
-                          certKeyFile=keyFile, certFile=certFile)
+                          certKeyFile=keyFile, certFile=certFile,
+                          cacertsFile=cacertsFile)
 
    # Get Service instance
    si = vim.ServiceInstance("ServiceInstance", stub)
@@ -532,7 +537,7 @@ def __FindSupportedVersion(protocol, server, port, path, preferredApiVersions):
 
 def SmartConnect(protocol='https', host='localhost', port=443, user='root', pwd='',
                  service="hostd", path="/sdk",
-                 preferredApiVersions=None):
+                 preferredApiVersions=None, cacertsFile=None):
    """
    Determine the most preferred API version supported by the specified server,
    then connect to the specified server using that API version, login and return
@@ -565,6 +570,8 @@ def SmartConnect(protocol='https', host='localhost', port=443, user='root', pwd=
                                 specified, the list of versions support by pyVmomi will
                                 be used.
    @type  preferredApiVersions: string or string list
+   @param cacertsFile CA certificates file in PEM format
+   @type  cacertsFile: string
    """
 
    if preferredApiVersions is None:
@@ -587,7 +594,8 @@ def SmartConnect(protocol='https', host='localhost', port=443, user='root', pwd=
                   service=service,
                   adapter='SOAP',
                   version=supportedVersion,
-                  path=path)
+                  path=path,
+                  cacertsFile=cacertsFile)
 
 def OpenUrlWithBasicAuth(url, user='root', pwd=''):
    """


### PR DESCRIPTION
Related open pyvmomi issues:

Certificate verify traceback when trying to connect to vcenter using SmartConnect() on Mac OS X Yosemite with python 2.7
https://github.com/vmware/pyvmomi/issues/235

PEP 0466 - SSL - Changes consideration
https://github.com/vmware/pyvmomi/issues/212

This does not allow unverified connections, but allows the caller to specify a trusted root certificate file.  By adding VMCA root certificates ( or organization root certificates as appropriate) to this file, secure verified connections can be made.