### PR TITLE
Make SmartConnect respect custom SSLContexts during version check

### DIFF
--- a/tests/fixtures/basic_container_view.yaml
+++ b/tests/fixtures/basic_container_view.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.7.0 CPython/2.7.10 Darwin/15.0.0]
     method: GET
-    uri: https://vcsa//sdk/vimServiceVersions.xml
+    uri: https://vcsa/sdk/vimServiceVersions.xml
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8" ?><namespaces
         version="1.0"><namespace><name>urn:vim25</name><version>6.0</version><priorVersions><version>5.5</version><version>5.1</version><version>5.0</version><version>4.1</version><version>4.0</version><version>2.5u2server</version><version>2.5u2</version><version>2.5</version></priorVersions></namespace><namespace><name>urn:vim2</name><version>2.0</version></namespace></namespaces>

--- a/tests/fixtures/iso8601_set_datetime.yaml
+++ b/tests/fixtures/iso8601_set_datetime.yaml
@@ -6,7 +6,7 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       User-Agent: [python-requests/2.3.0 CPython/3.4.1 Darwin/13.3.0]
     method: GET
-    uri: https://vcsa:443//sdk/vimServiceVersions.xml
+    uri: https://vcsa:443/sdk/vimServiceVersions.xml
   response:
     body: {string: "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n<!--\n   Copyright
         2008-2012 VMware, Inc.  All rights reserved.\n-->\n<namespaces version=\"1.0\">\n

--- a/tests/fixtures/root_folder_parent.yaml
+++ b/tests/fixtures/root_folder_parent.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.7.0 CPython/2.7.10 Darwin/15.0.0]
     method: GET
-    uri: https://vcsa//sdk/vimServiceVersions.xml
+    uri: https://vcsa/sdk/vimServiceVersions.xml
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8" ?><namespaces
         version="1.0"><namespace><name>urn:vim25</name><version>6.0</version><priorVersions><version>5.5</version><version>5.1</version><version>5.0</version><version>4.1</version><version>4.0</version><version>2.5u2server</version><version>2.5u2</version><version>2.5</version></priorVersions></namespace><namespace><name>urn:vim2</name><version>2.0</version></namespace></namespaces>

--- a/tests/fixtures/smart_connection.yaml
+++ b/tests/fixtures/smart_connection.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.7.0 CPython/2.7.10 Darwin/15.0.0]
     method: GET
-    uri: https://vcsa//sdk/vimServiceVersions.xml
+    uri: https://vcsa/sdk/vimServiceVersions.xml
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8" ?><namespaces
         version="1.0"><namespace><name>urn:vim25</name><version>6.0</version><priorVersions><version>5.5</version><version>5.1</version><version>5.0</version><version>4.1</version><version>4.0</version><version>2.5u2server</version><version>2.5u2</version><version>2.5</version></priorVersions></namespace><namespace><name>urn:vim2</name><version>2.0</version></namespace></namespaces>

--- a/tests/fixtures/test_vm_config_iso8601.yaml
+++ b/tests/fixtures/test_vm_config_iso8601.yaml
@@ -6,7 +6,7 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       User-Agent: [python-requests/2.3.0 CPython/3.4.1 Darwin/13.3.0]
     method: GET
-    uri: https://vcsa:443//sdk/vimServiceVersions.xml
+    uri: https://vcsa:443/sdk/vimServiceVersions.xml
   response:
     body: {string: "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n<!--\n   Copyright
         2008-2012 VMware, Inc.  All rights reserved.\n-->\n<namespaces version=\"1.0\">\n

--- a/tests/fixtures/vm_nic_data.yaml
+++ b/tests/fixtures/vm_nic_data.yaml
@@ -6,7 +6,7 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       User-Agent: [python-requests/2.3.0 CPython/3.4.1 Darwin/13.3.0]
     method: GET
-    uri: https://vcsa:443//sdk/vimServiceVersions.xml
+    uri: https://vcsa:443/sdk/vimServiceVersions.xml
   response:
     body: {string: "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n<!--\n   Copyright
         2008-2012 VMware, Inc.  All rights reserved.\n-->\n<namespaces version=\"1.0\">\n


### PR DESCRIPTION
Also modify test fixtures to not expect an extra slash in uri from SmartConnect