### PR TITLE
Python3 fixes for SoapAdapter serializer.

### DIFF
--- a/pyVmomi/VmomiSupport.py
+++ b/pyVmomi/VmomiSupport.py
@@ -21,6 +21,7 @@ from six import iteritems
 from six import iterkeys
 from six import itervalues
 from six import text_type
+from six import binary_type
 from six import PY3
 from datetime import datetime
 from pyVmomi import Iso8601
@@ -314,6 +315,13 @@ def FormatObject(val, info=Object(name="", type=object, flags=0), indent=0):
       result = Iso8601.ISO8601Format(val)
    elif isinstance(val, binary):
       result = base64.b64encode(val)
+      if PY3:
+         # In python3 the bytes result after the base64 encoding has a
+         # leading 'b' which causes error when we use it to construct the
+         # soap message. Workaround the issue by converting the result to
+         # string. Since the result of base64 encoding contains only subset
+         # of ASCII chars, converting to string will not change the value.
+         result = str(result, 'utf-8')
    else:
       result = repr(val)
    return start + result
@@ -1290,7 +1298,7 @@ byte  = type("byte", (int,), {})
 short  = type("short", (int,), {})
 double = type("double", (float,), {})
 URI = type("URI", (str,), {})
-binary = type("binary", (str,), {})
+binary = type("binary", (binary_type,), {})
 PropertyPath = type("PropertyPath", (text_type,), {})
 
 # _wsdlTypeMapNSs store namespaces added to _wsdlTypeMap in _SetWsdlType

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -58,3 +58,14 @@ class SerializerTests(tests.VCRTestBase):
         val = vim.vm.device.VirtualDeviceSpec.FileOperation()
         # This line should not raise an exception, especially on Python 3.
         SoapAdapter.Serialize(val)
+
+    def test_serialize_integer(self):
+        lp = vim.LongPolicy()
+        lp.inherited = False
+        lp.value = 100
+        SoapAdapter.Serialize(lp, version='vim.version.version10')
+
+    def test_serialize_float(self):
+        pc = vim.host.VsanInternalSystem.PolicyCost()
+        pc.diskSpaceToAddressSpaceRatio = 1.0
+        SoapAdapter.Serialize(pc, version='vim.version.version10')


### PR DESCRIPTION
1. Remove the encode() helper method since it doesn't provide encoding in python3 at all.
2. In order to workaround the leading 'b' literal after encoding in python3,
   we delay the encoding step and will encode the whole soap message instead of individual values.
3. Added separate cases to handle Enum, integer and float to make the serializtion process more clear.