### PR TITLE
Remove global ServiceInstance

### DIFF
--- a/pyVim/connect.py
+++ b/pyVim/connect.py
@@ -46,13 +46,6 @@ See http://www.ietf.org/rfc/rfc3986.txt sec 3.2.2
 """
 _rx = re.compile(r"(^\[.+\]|[^:]+)(:\d+)?$")
 
-_si = None
-"""
-Global (thread-shared) ServiceInstance
-
-@todo: Get rid of me?
-"""
-
 
 def localSslFixup(host, sslContext):
     """
@@ -267,8 +260,6 @@ def Connect(host='localhost', port=443, user='root', pwd='',
       raise Exception('''The provided connection mechanism is not available, the
               supported mechanisms are userpass or sspi''')
 
-   SetSi(si)
-
    return si
 
 
@@ -279,7 +270,6 @@ def Disconnect(si):
    """
    # Logout
    __Logout(si)
-   SetSi(None)
 
 
 ## Method that gets a local ticket for the specified user
@@ -472,31 +462,6 @@ def __RetrieveContent(host, port, adapter, version, path, keyFile, certFile,
 
    return content, si, stub
 
-
-## Get the saved service instance.
-
-def GetSi():
-   """ Get the saved service instance. """
-   return _si
-
-
-## Set the saved service instance.
-
-def SetSi(si):
-   """ Set the saved service instance. """
-
-   global _si
-   _si = si
-
-
-## Get the global saved stub
-
-def GetStub():
-   """ Get the global saved stub. """
-   si = GetSi()
-   if si:
-      return si._GetStub()
-   return None;
 
 ## RAII-style class for managing connections
 


### PR DESCRIPTION
I need to be able to create multiple concurrent active sessions. Having a single global ServiceInstance does not really fit with this usage and nothing in the code requires this actually exist.