### PR TITLE
Fix #351: Detect vApps in getallvms sample

### DIFF
--- a/sample/getallvms.py
+++ b/sample/getallvms.py
@@ -48,7 +48,7 @@ def GetArgs():
 def PrintVmInfo(vm, depth=1):
    """
    Print information for a particular virtual machine or recurse into a folder
-    with depth protection
+   or vApp with depth protection
    """
    maxdepth = 10
 
@@ -60,6 +60,14 @@ def PrintVmInfo(vm, depth=1):
       vmList = vm.childEntity
       for c in vmList:
          PrintVmInfo(c, depth+1)
+      return
+
+   # if this is a vApp, it likely contains child VMs
+   # (vApps can nest vApps, but it is hardly a common usecase, so ignore that)
+   if isinstance(vm, vim.VirtualApp):
+      vmList = vm.vm
+      for c in vmList:
+         PrintVmInfo(c, depth + 1)
       return
 
    summary = vm.summary


### PR DESCRIPTION
VM folders may contain vApps. If a vApp is detected, print its
child VMs.

A vApp may contain child vApps too, but since this is a rare
usecase, nested vApps and their child VMs are ignored.

Signed-off-by: Martin Mosegaard Amdisen <martin.amdisen@praqma.com>