### PR TITLE
Import vim from pyVmomi

### DIFF
--- a/sample/getallvms.py
+++ b/sample/getallvms.py
@@ -21,6 +21,7 @@ Python program for listing the vms on an ESX / vCenter host
 from __future__ import print_function
 
 from pyVim.connect import SmartConnect, Disconnect
+from pyVmomi import vim
 
 import argparse
 import atexit


### PR DESCRIPTION
Import vim so that sample code will run properly

Otherwise, will receive the following traceback:

`
Traceback (most recent call last):
  File "getallvms.py", line 129, in <module>
    main()
  File "getallvms.py", line 124, in main
    PrintVmInfo(vm)
  File "getallvms.py", line 63, in PrintVmInfo
    PrintVmInfo(c, depth+1)
  File "getallvms.py", line 63, in PrintVmInfo
    PrintVmInfo(c, depth+1)
  File "getallvms.py", line 68, in PrintVmInfo
    if isinstance(vm, vim.VirtualApp):
NameError: global name 'vim' is not defined
`