### PR TITLE
Fix #487: Remove custom __getattr__ in _HTTPSConnection

### DIFF
--- a/pyVmomi/SoapAdapter.py
+++ b/pyVmomi/SoapAdapter.py
@@ -1054,11 +1054,6 @@ class _HTTPSConnection(http_client.HTTPSConnection):
          #      dercert = self.sock.getpeercert(False)
          #      # pemcert = ssl.DER_cert_to_PEM_cert(dercert)
 
-   def __getattr__(self, item):
-      if item == 'connect':
-         return self.connect(self._wrapped)
-      return getattr(self._wrapped, item)
-
 ## Stand-in for the HTTPSConnection class that will connect to a proxy and
 ## issue a CONNECT command to start an SSL tunnel.
 class SSLTunnelConnection(object):


### PR DESCRIPTION
This prevents maximum recursion depth errors when referencing _HTTPSConnection.connect. The custom \_\_getattr\_\_ was a leftover from https://github.com/vmware/pyvmomi/commit/21a5d52e6a9f0742c14640edead762d2eda8951a which removed the '_wrapped' attribute.