### PR TITLE
[DOC] Fix guest os state

### DIFF
--- a/docs/vim/vm/GuestInfo.rst
+++ b/docs/vim/vm/GuestInfo.rst
@@ -84,7 +84,7 @@ Attributes:
         * "shuttingdown" - Guest has a pending shutdown command.
         * "resetting" - Guest has a pending reset command.
         * "standby" - Guest has a pending standby command.
-        * "notrunning" - Guest is not running.
+        * "notRunning" - Guest is not running.
         * "unknown" - Guest information is not available.
         * 
     appHeartbeatStatus (`str`_, optional):


### PR DESCRIPTION
According to the code, guest os not running state is : "notRunning"

```python
CreateEnumType("vim.vm.GuestInfo.GuestState", "VirtualMachineGuestState", "vim.version.version1", ["running", "shuttingDown", "resetting", "standby", "notRunning", "unknown"])
```