### PR TITLE
fix vcrpy version requirement for testing, reduce verbosity of test log

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
 tox
 testtools>=0.9.34
-vcrpy==1.12.0
+vcrpy<2

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -44,5 +44,6 @@ class VCRTestBase(unittest.TestCase):
     def setUp(self):
         monkey_patch_vcrpy()
         logging.basicConfig()
-        vcr_log = logging.getLogger('vcr')
-        vcr_log.setLevel(logging.DEBUG)
+      # pretty loud with mismatch warnings...
+      # vcr_log = logging.getLogger('vcr')
+      # vcr_log.setLevel(logging.DEBUG)


### PR DESCRIPTION
This fixes #735 

```
jking@dvm:~/pyvmomi$ tox
GLOB sdist-make: /home/jking/pyvmomi/setup.py
py27 create: /home/jking/pyvmomi/.tox/py27
py27 installdeps: -rtest-requirements.txt
py27 inst: /home/jking/pyvmomi/.tox/dist/pyvmomi-6.7.1.zip
py27 installed: certifi==2018.10.15,chardet==3.0.4,contextlib2==0.5.5,extras==1.0.0,filelock==3.0.10,fixtures==3.0.0,funcsigs==1.0.2,idna==2.7,linecache2==1.0.0,mock==2.0.0,pbr==5.1.0,pkg-resources==0.0.0,pluggy==0.8.0,py==1.7.0,python-mimeparse==1.6.0,pyvmomi==6.7.1,PyYAML==3.13,requests==2.20.0,six==1.11.0,testtools==2.3.0,toml==0.10.0,tox==3.5.3,traceback2==1.4.0,unittest2==1.1.0,urllib3==1.24.1,vcrpy==1.13.0,virtualenv==16.1.0,wrapt==1.10.11
py27 runtests: PYTHONHASHSEED='1076960615'
py27 runtests: commands[0] | python setup.py test
running test
running egg_info
writing dependency_links to pyvmomi.egg-info/dependency_links.txt
writing pyvmomi.egg-info/PKG-INFO
writing top-level names to pyvmomi.egg-info/top_level.txt
writing requirements to pyvmomi.egg-info/requires.txt
reading manifest file 'pyvmomi.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'pyvmomi.egg-info/SOURCES.txt'
running build_ext
test_basic_container_view (tests.test_container_view.ContainerViewTests) ... ok
test_root_folder_parent (tests.test_managed_object.ManagedObjectTests) ... ok
test_iso8601_set_datetime (tests.test_iso8601.Iso8601Tests) ... ok
test_vm_config_iso8601 (tests.test_iso8601.Iso8601Tests) ... ok
test_request_context_serializer_global (tests.test_serializer.SerializerTests) ... ok
test_request_context_serializer_instance (tests.test_serializer.SerializerTests) ... ok
test_serialize_float (tests.test_serializer.SerializerTests) ... ok
test_serialize_integer (tests.test_serializer.SerializerTests) ... ok
test_serialize_object (tests.test_serializer.SerializerTests) ... ok
test_serialize_unicode (tests.test_serializer.SerializerTests) ... ok
test_simple_request_serializer (tests.test_serializer.SerializerTests) ... ok
test_basic_connection (tests.test_connect.ConnectionTests) ... ok
test_basic_connection_bad_password (tests.test_connect.ConnectionTests) ... ok
test_disconnect_on_no_connection (tests.test_connect.ConnectionTests) ... ok
test_smart_connection (tests.test_connect.ConnectionTests) ... ok
test_ssl_tunnel (tests.test_connect.ConnectionTests) ... ok
test_ssl_tunnel_http_failure (tests.test_connect.ConnectionTests) ... ok
test_sspi_connection (tests.test_connect.ConnectionTests) ... ok
test_vm_nic_data (tests.test_virtual_machine_object.VirtualMachineTests) ... ok
test_invoke_method_login_session_exception (tests.test_vim_session_oriented_stub.SoapAdapterTests) ... ok
test_json_datacenter_explode (tests.test_json.JSONTests) ... ok
test_json_datastore_explode (tests.test_json.JSONTests) ... ok
test_json_host_explode (tests.test_json.JSONTests) ... ok
test_json_network_explode (tests.test_json.JSONTests) ... ok
test_json_vm_explode_default (tests.test_json.JSONTests) ... ok
test_json_vm_explode_objs_match (tests.test_json.JSONTests) ... ok
test_json_vm_explode_type_match (tests.test_json.JSONTests) ... ok
test_pbm_check_compatibility (tests.test_pbm_check_compatibility.PBMTests) ... ok

----------------------------------------------------------------------
Ran 28 tests in 7.912s

OK
py36 create: /home/jking/pyvmomi/.tox/py36
py36 installdeps: -rtest-requirements.txt
py36 inst: /home/jking/pyvmomi/.tox/dist/pyvmomi-6.7.1.zip
py36 installed: certifi==2018.10.15,chardet==3.0.4,extras==1.0.0,filelock==3.0.10,fixtures==3.0.0,idna==2.7,linecache2==1.0.0,multidict==4.4.2,pbr==5.1.0,pkg-resources==0.0.0,pluggy==0.8.0,py==1.7.0,python-mimeparse==1.6.0,pyvmomi==6.7.1,PyYAML==3.13,requests==2.20.0,six==1.11.0,testtools==2.3.0,toml==0.10.0,tox==3.5.3,traceback2==1.4.0,unittest2==1.1.0,urllib3==1.24.1,vcrpy==1.13.0,virtualenv==16.1.0,wrapt==1.10.11,yarl==1.2.6
py36 runtests: PYTHONHASHSEED='1076960615'
py36 runtests: commands[0] | python setup.py test
running test
running egg_info
writing pyvmomi.egg-info/PKG-INFO
writing dependency_links to pyvmomi.egg-info/dependency_links.txt
writing requirements to pyvmomi.egg-info/requires.txt
writing top-level names to pyvmomi.egg-info/top_level.txt
reading manifest file 'pyvmomi.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'pyvmomi.egg-info/SOURCES.txt'
running build_ext
test_basic_container_view (tests.test_container_view.ContainerViewTests) ... ok
test_root_folder_parent (tests.test_managed_object.ManagedObjectTests) ... ok
test_iso8601_set_datetime (tests.test_iso8601.Iso8601Tests) ... ok
test_vm_config_iso8601 (tests.test_iso8601.Iso8601Tests) ... ok
test_request_context_serializer_global (tests.test_serializer.SerializerTests) ... ok
test_request_context_serializer_instance (tests.test_serializer.SerializerTests) ... ok
test_serialize_float (tests.test_serializer.SerializerTests) ... ok
test_serialize_integer (tests.test_serializer.SerializerTests) ... ok
test_serialize_object (tests.test_serializer.SerializerTests) ... ok
test_serialize_unicode (tests.test_serializer.SerializerTests) ... ok
test_simple_request_serializer (tests.test_serializer.SerializerTests) ... ok
test_basic_connection (tests.test_connect.ConnectionTests) ... ok
test_basic_connection_bad_password (tests.test_connect.ConnectionTests) ... ok
test_disconnect_on_no_connection (tests.test_connect.ConnectionTests) ... ok
test_smart_connection (tests.test_connect.ConnectionTests) ... ok
test_ssl_tunnel (tests.test_connect.ConnectionTests) ... /home/jking/pyvmomi/tests/test_connect.py:90: ResourceWarning: unclosed <ssl.SSLSocket fd=3, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('0.0.0.0', 0)>
  connect.SoapStubAdapter('sdkTunnel', 8089, httpProxyHost='vcsa').GetConnection()
ok
test_ssl_tunnel_http_failure (tests.test_connect.ConnectionTests) ... ok
test_sspi_connection (tests.test_connect.ConnectionTests) ... ok
test_vm_nic_data (tests.test_virtual_machine_object.VirtualMachineTests) ... ok
test_invoke_method_login_session_exception (tests.test_vim_session_oriented_stub.SoapAdapterTests) ... ok
test_json_datacenter_explode (tests.test_json.JSONTests) ... ok
test_json_datastore_explode (tests.test_json.JSONTests) ... ok
test_json_host_explode (tests.test_json.JSONTests) ... ok
test_json_network_explode (tests.test_json.JSONTests) ... ok
test_json_vm_explode_default (tests.test_json.JSONTests) ... ok
test_json_vm_explode_objs_match (tests.test_json.JSONTests) ... ok
test_json_vm_explode_type_match (tests.test_json.JSONTests) ... ok
test_pbm_check_compatibility (tests.test_pbm_check_compatibility.PBMTests) ... ok

----------------------------------------------------------------------
Ran 28 tests in 7.536s

OK
__________________________________________________________________________________________ summary ___________________________________________________________________________________________
  py27: commands succeeded
  py36: commands succeeded
  congratulations :)
```