### PR TITLE
add connection close in __GetElementTree

### DIFF
--- a/pyVim/connect.py
+++ b/pyVim/connect.py
@@ -603,6 +603,7 @@ def __GetElementTree(protocol, server, port, path, sslContext):
       raise Exception("Protocol " + protocol + " not supported.")
    conn.request("GET", path)
    response = conn.getresponse()
+   conn.close()
    if response.status == 200:
       try:
          tree = ElementTree.fromstring(response.read())


### PR DESCRIPTION
python unittest giving warning 
/usr/local/lib/python3.6/site-packages/pyVim/connect.py:638: ResourceWarning: unclosed <ssl.SSLSocket fd=7, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6,

added conn.close() to close the connection and prevent this warning