### PR TITLE
support CONNECT based proxies

### DIFF
--- a/pyVim/connect.py
+++ b/pyVim/connect.py
@@ -577,7 +577,7 @@ class SmartConnection(object):
          Disconnect(self.si)
          self.si = None
 
-def __GetElementTree(protocol, server, port, path, sslContext):
+def __GetElementTree(protocol, server, port, path, sslContext, httpProxyHost=None, httpProxyPort=None):
    """
    Private method that returns a root from ElementTree for a remote XML document.
 
@@ -594,7 +594,11 @@ def __GetElementTree(protocol, server, port, path, sslContext):
    @type  sslContext: SSL.Context
    """
 
-   if protocol == "https":
+   if httpProxyHost:
+      kwargs = {"context": sslContext} if sslContext else {}
+      conn = http_client.HTTPSConnection(httpProxyHost, port=httpProxyPort, **kwargs)
+      conn.set_tunnel(server, port)
+   elif protocol == "https":
       kwargs = {"context": sslContext} if sslContext else {}
       conn = http_client.HTTPSConnection(server, port=port, **kwargs)
    elif protocol == "http":
@@ -615,7 +619,7 @@ def __GetElementTree(protocol, server, port, path, sslContext):
 ## supported by the specified server.  The result will be vimServiceVersions.xml
 ## if it exists, otherwise vimService.wsdl if it exists, otherwise None.
 
-def __GetServiceVersionDescription(protocol, server, port, path, sslContext):
+def __GetServiceVersionDescription(protocol, server, port, path, sslContext, httpProxyHost=None, httpProxyPort=None):
    """
    Private method that returns a root from an ElementTree describing the API versions
    supported by the specified server.  The result will be vimServiceVersions.xml
@@ -635,12 +639,14 @@ def __GetServiceVersionDescription(protocol, server, port, path, sslContext):
    """
 
    tree = __GetElementTree(protocol, server, port,
-                           path + "/vimServiceVersions.xml", sslContext)
+                           path + "/vimServiceVersions.xml", sslContext,
+                           httpProxyHost, httpProxyPort)
    if tree is not None:
       return tree
 
    tree = __GetElementTree(protocol, server, port,
-                           path + "/vimService.wsdl", sslContext)
+                           path + "/vimService.wsdl", sslContext,
+                           httpProxyHost, httpProxyPort)
    return tree
 
 
@@ -689,7 +695,7 @@ def __VersionIsSupported(desiredVersion, serviceVersionDescription):
 ## Private method that returns the most preferred API version supported by the
 ## specified server,
 
-def __FindSupportedVersion(protocol, server, port, path, preferredApiVersions, sslContext):
+def __FindSupportedVersion(protocol, server, port, path, preferredApiVersions, sslContext, httpProxyHost=None, httpProxyPort=None):
    """
    Private method that returns the most preferred API version supported by the
    specified server,
@@ -715,7 +721,9 @@ def __FindSupportedVersion(protocol, server, port, path, preferredApiVersions, s
                                                               server,
                                                               port,
                                                               path,
-                                                              sslContext)
+                                                              sslContext,
+                                                              httpProxyHost,
+                                                              httpProxyPort)
    if serviceVersionDescription is None:
       return None
 
@@ -759,7 +767,10 @@ def SmartStubAdapter(host='localhost', port=443, path='/sdk',
                                              port,
                                              path,
                                              preferredApiVersions,
-                                             sslContext)
+                                             sslContext,
+                                             httpProxyHost,
+                                             httpProxyPort
+                                             )
    if supportedVersion is None:
       raise Exception("%s:%s is not a VIM server" % (host, port))
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 tox
 testtools>=0.9.34
 vcrpy<2
+mock

--- a/tests/fixtures/http_proxy.yaml
+++ b/tests/fixtures/http_proxy.yaml
@@ -3,21 +3,21 @@ interactions:
     body: null
     headers: {}
     method: GET
-    uri: https://vcsa:80/
+    uri: https://my-http-proxy:8080/
   response:
     body:
-      string: ""
+      string: "bla"
     headers:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '0'
+      - '3'
       Content-Security-Policy:
       - block-all-mixed-content
       Content-Type:
       - text/html
       Date:
-      - Wed, 26 Jun 2019 20:19:39 GMT
+      - Wed, 26 Jun 2019 20:49:55 GMT
       Strict-Transport-Security:
       - max-age=31536000
       X-Content-Type-Options:
@@ -27,6 +27,6 @@ interactions:
       X-XSS-Protection:
       - '1'
     status:
-      code: 404
-      message: KO
+      code: 200
+      message: OK
 version: 1


### PR DESCRIPTION
- ensure the proxy configuration is passed to `__GetElementTree()`
- ruse @blacksponge fix for the  `SSLTunnelConnection` class
- remove `test_ssl_tunnel_http_failure` because the error will happen later

closes: #620
closes: #567
closes: #198