### PR TITLE
Quote arguments with square brackets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ posted to `pypi <https://pypi.python.org/pypi/pyvmomi/>`_
   ``python setup.py develop`` for development install or 
   ``python setup.py install``.
 * To install `github's version <https://github.com/vmware/pyvmomi>`_ with sso support, just run
-  ``pip install -e .[sso]`` inside project's home folder.
+  ``pip install -e ".[sso]"`` inside project's home folder.
 
 Testing
 =======


### PR DESCRIPTION
Square brackets are interpreted by some shells (e.g. zsh) so it's better
to surround them with quotes when used on the command line.