### PR TITLE
Allow passing ssl_context when login with token

### DIFF
--- a/pyVim/connect.py
+++ b/pyVim/connect.py
@@ -115,13 +115,14 @@ class VimSessionOrientedStub(SessionOrientedStub):
       return _doLogin
 
    @staticmethod
-   def makeCertHokTokenLoginMethod(stsUrl, stsCert=None):
+   def makeCertHokTokenLoginMethod(stsUrl, stsCert=None, ssl_context=None):
       '''Return a function that will call the vim.SessionManager.LoginByToken()
       after obtaining a HoK SAML token from the STS. The result of this function
       can be passed as the "loginMethod" to a SessionOrientedStub constructor.
 
       @param stsUrl: URL of the SAML Token issuing service. (i.e. SSO server).
       @param stsCert: public key of the STS service.
+      @param ssl_context: SSL context
       '''
       assert(stsUrl)
 
@@ -132,7 +133,7 @@ class VimSessionOrientedStub(SessionOrientedStub):
          authenticator = sso.SsoAuthenticator(sts_url=stsUrl,
                                               sts_cert=stsCert)
 
-         samlAssertion = authenticator.get_hok_saml_assertion(cert,key)
+         samlAssertion = authenticator.get_hok_saml_assertion(cert, key, ssl_context=ssl_context)
 
 
          def _requestModifier(request):
@@ -154,7 +155,8 @@ class VimSessionOrientedStub(SessionOrientedStub):
    def makeCredBearerTokenLoginMethod(username,
                                       password,
                                       stsUrl,
-                                      stsCert=None):
+                                      stsCert=None,
+                                      ssl_context=None):
       '''Return a function that will call the vim.SessionManager.LoginByToken()
       after obtaining a Bearer token from the STS. The result of this function
       can be passed as the "loginMethod" to a SessionOrientedStub constructor.
@@ -163,6 +165,7 @@ class VimSessionOrientedStub(SessionOrientedStub):
       @param password: password of the user/service registered with STS.
       @param stsUrl: URL of the SAML Token issueing service. (i.e. SSO server).
       @param stsCert: public key of the STS service.
+      @param ssl_context: SSL context
       '''
       assert(username)
       assert(password)
@@ -177,7 +180,8 @@ class VimSessionOrientedStub(SessionOrientedStub):
          samlAssertion = authenticator.get_bearer_saml_assertion(username,
                                                                  password,
                                                                  cert,
-                                                                 key)
+                                                                 key,
+                                                                 ssl_context=ssl_context)
          si = vim.ServiceInstance("ServiceInstance", soapStub)
          sm = si.content.sessionManager
          if not sm.currentSession:


### PR DESCRIPTION
When we login with either bearer or HoK token, there should be an option
to pass an ssl_context in order to support self-signed certificates.