### PR TITLE
Update version.py to remove warnings in py3.8

### DIFF
--- a/pyVmomi/Version.py
+++ b/pyVmomi/Version.py
@@ -23,7 +23,7 @@ def AddVersion(version, ns, versionId='', isLegacy=0, serviceNs=''):
       nsMap[version] = ns
       if len(versionId) > 0:
          versionMap[ns + '/' + versionId] = version
-      if isLegacy or ns is "":
+      if isLegacy or ns == "":
          versionMap[ns] = version
       versionIdMap[version] = versionId
       if not serviceNs:


### PR DESCRIPTION
"is" was misused here.