### PR TITLE
docs: fix simple typo, throrough -> thorough

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ To get started, see the `getting started guide <http://vmware.github.io/pyvmomi-
 * community discussion on IRC freenode.net channels `#pyvmomi and #pyvmomi-dev <http://webchat.freenode.net/?channels=#pyvmomi,#pyvmomi-dev>`_
 * community email is on `nabble <http://pyvmomi.2338814.n4.nabble.com>`_
 
-Don't know what pip is? Any serious python developer should know, so here's a `throrough intro to pip <http://www.dabapps.com/blog/introduction-to-pip-and-virtualenv-python/>`_ that we like.
+Don't know what pip is? Any serious python developer should know, so here's a `thorough intro to pip <http://www.dabapps.com/blog/introduction-to-pip-and-virtualenv-python/>`_ that we like.
 
 Installing
 ==========


### PR DESCRIPTION
There is a small typo in README.rst.

Should read `thorough` rather than `throrough`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md