### PR TITLE
Change the order of comparison in ManagedObject __eq__ method

### DIFF
--- a/pyVmomi/VmomiSupport.py
+++ b/pyVmomi/VmomiSupport.py
@@ -597,8 +597,8 @@ class ManagedObject(object):
       if other is None:
          return False
       else:
-         return self._moId == other._moId and \
-                self.__class__ == other.__class__ and \
+         return self.__class__ == other.__class__ and \
+                self._moId == other._moId and \
                 self._serverGuid == other._serverGuid
 
    def __ne__(self, other):


### PR DESCRIPTION
The current implementation does not allow for a comparison of `ManagedObject` with the instances of other classes, as they lead to `AttributeError`. Per my understanding, it would be better to just return `False`, when one compares the instance of `ManagedObject` with any instance of other classes.