### PR TITLE
SmartConnect is failing when using SAML tokens.

### DIFF
--- a/pyVim/connect.py
+++ b/pyVim/connect.py
@@ -454,12 +454,6 @@ def __Login(host,
     if adapter != "SOAP":
         raise ValueError(adapter)
 
-    # Add an HTTP authorization header if a token is provided
-    if token and tokenType == TOKEN_TYPE_SAML:
-        if customHeaders is None:
-            customHeaders = {}
-        customHeaders.update({"Authorization": "Bearer {}".format(token)})
-
     # Create the SOAP stub adapter
     stub = SoapStubAdapter(
         host,
@@ -474,7 +468,8 @@ def __Login(host,
         sslContext=sslContext,
         httpConnectionTimeout=httpConnectionTimeout,
         connectionPoolTimeout=connectionPoolTimeout,
-        customHeaders=customHeaders)
+        customHeaders=customHeaders,
+        samlToken=token)
 
     # Get Service instance
     si = vim.ServiceInstance("ServiceInstance", stub)


### PR DESCRIPTION
This is how I fixed #1004 
It looks like the token was being put in the wrong place in the POST request? 

I added the samlToken parameter to SoapStubAdapter() seemed to fix it. 
Also, I removed the addition of the samlToken to customHeaders, and it still worked.

I am using vcenter 6.7, so this may not be appropriate for later versions of vcenter.  I don't have a way to test it on later version of vcenter. But this seems necessary for 6.7. 
