### PR TITLE
Fix values for host, port for proxy connection

### DIFF
--- a/pyVmomi/SoapAdapter.py
+++ b/pyVmomi/SoapAdapter.py
@@ -1552,7 +1552,7 @@ class SoapStubAdapter(SoapStubAdapterBase):
                     conn.setVcTunnel(self.sslProxyPath)
                 elif hasattr(self, 'httpProxyHost'):
                     customHeaders = self._customHeaders if self._customHeaders else {}
-                    conn.set_tunnel(host, port, customHeaders)
+                    conn.set_tunnel(self.host.rsplit(":", 1)[0], self.port, customHeaders)
             _Connect(connection=conn, serverPemCert=self.serverPemCert, thumbprint=self.thumbprint)
 
         return conn


### PR DESCRIPTION
This pull request includes a small change to the `pyVmomi/SoapAdapter.py` file. The change modifies the `GetConnection` method to correctly set the tunnel using the `host` and `port` attributes.

The command `mitmproxy --showhost` was used to setup a proxy. Tested with `python3.11` on macOS 15.1.1.

```python
instance = SmartConnect(
    host="myhostname",
    user="myusername",
    pwd="supersecret",
    disableSslCertValidation=True,
    httpProxyHost="127.0.0.1",
    httpProxyPort=8080,
)
```

Leads to

```python
pyVmomi.VmomiSupport.vim.fault.HostConnectFault: (vim.fault.HostConnectFault) {
   dynamicType = <unset>,
   dynamicProperty = (vmodl.DynamicProperty) [],
   msg = 'Tunnel connection failed: 502 Bad Gateway',
   faultCause = <unset>,
   faultMessage = (vmodl.LocalizableMessage) []
}
```

The issue is rooted at:

https://github.com/vmware/pyvmomi/blob/9a8956f7b4a91b491e63454b3eb3c59d4abb8a31/pyVmomi/SoapAdapter.py#L1541-L1542

https://github.com/vmware/pyvmomi/blob/9a8956f7b4a91b491e63454b3eb3c59d4abb8a31/pyVmomi/SoapAdapter.py#L1549-L1555

[Python documentation](https://docs.python.org/3.11/library/http.client.html#http.client.HTTPConnection.set_tunnel) states

> HTTPConnection.set_tunnel(host, port=None, headers=None)
>  Set the host and the port for HTTP Connect Tunnelling. This allows running the connection through a proxy server.
> 
> The host and port arguments specify the endpoint of the tunneled connection **(i.e. the address included in the CONNECT request, not the address of the proxy server).**

Line 1555 sets the the proxy host and port from line 1541 and 1542 as endpoint, which leads to the `Tunnel connection failed: 502 Bad Gateway` error. This should be `self.host` (formatted) and `self.port`
