### PR TITLE
Remove usage of OpenSSL.crypto.sign

### DIFF
--- a/pyVim/sso.py
+++ b/pyVim/sso.py
@@ -20,6 +20,8 @@ else:
     from cgi import escape
 #Third-party imports.
 from lxml import etree
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import padding
 from OpenSSL import crypto
 import ssl
 
@@ -790,7 +792,20 @@ def _sign(private_key, data, digest=SHA256):
     # Convert private key in arbitrary format into DER (DER is binary format
     # so we get rid of \n / \r\n differences, and line breaks in PEM).
     pkey = _load_private_key(_extract_certificate(private_key))
-    return base64.b64encode(crypto.sign(pkey, data.encode(UTF_8), digest))
+    crypto_key = pkey.to_cryptography_key()
+    if digest == SHA256:
+        hash_alg = hashes.SHA256()
+    elif digest == SHA512:
+        hash_alg = hashes.SHA512()
+    else:
+        raise ValueError("Unsupported digest algorithm: %s" % digest)
+
+    signed = crypto_key.sign(
+        data.encode(UTF_8),
+        padding.PKCS1v15(),
+        hash_alg
+    )
+    return base64.b64encode(signed)
 
 
 def _canonicalize(xml_string):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 
 [project.optional-dependencies]
 sso = [
-    "pyOpenSSL<24.3.0",
+    "pyOpenSSL",
     "lxml",
 ]
 


### PR DESCRIPTION
This method has been removed in PyOpenSSL 24.3.0.
This change replaces it with equivalent functions from python's cryptography library.
In this way, the pyvim module can be used with recent versions of PyOpenSSL. This needed in particular due to CVE-2026-27459, which requires upgrading PyOpenSSL to 26.0.0.

Changes in this commit:
- Update the signing logic inside pyVim/sso.py's _sign helper to leverage Python's cryptography package primitives, replacing the legacy OpenSSL.crypto.sign wrapper.
- Remove the constraint on pyOpenSSL in pyproject.toml. The whole repository is not using any other deprecated or removed feature in puOpenSSL.

Resolves: #1112